### PR TITLE
add credential support for streamlit server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
+# vscode config
+.vscode
+
 # cache
 __pycache__
-.vscode
 
 # virtual environment
 activate.ps1
 environment
+
+# secrets
+.streamlit
 
 # tests
 tests

--- a/modules/mail.py
+++ b/modules/mail.py
@@ -9,6 +9,10 @@ def send_mail(sender:str, body: str, email: str = os.getenv('email'), password: 
         placeholder.warning('Either sender or message is missing. Try again.')
         return time.sleep(2)
 
+    if email is None:
+        email = st.secrets['email']
+        password = st.secrets['password']
+
     cls()
 
     time.sleep(1)


### PR DESCRIPTION
When deploying to streamlit server. The app cant' retrieve the secret creds from streamlit with os.getenv(), like Heroku, instead, they use st.secrets to retrieve it.